### PR TITLE
feat: adds ability to override localhost with env var for cdn methods

### DIFF
--- a/src/Local.php
+++ b/src/Local.php
@@ -333,8 +333,7 @@ class Local extends Base implements Driver
         $sUrl = str_replace('{{hash}}', $sHash, $sUrl);
         $sUrl = str_replace('{{filename}}', urlencode($sFilename), $sUrl);
 
-            return $sUrl;
-        }
+        return $sUrl;
     }
 
     // --------------------------------------------------------------------------

--- a/src/Local.php
+++ b/src/Local.php
@@ -268,7 +268,13 @@ class Local extends Base implements Driver
         $sUrl = str_replace('{{filename}}', $sFilename, $sUrl);
         $sUrl = str_replace('{{extension}}', $sExtension, $sUrl);
 
-        return $sUrl;
+        //  Check for env for CDN_URL override env
+        if (!empty($_ENV['CDN_URL'])) {
+            return str_replace('localhost', $_ENV['CDN_URL'], $sUrl); // Local dev hack
+        } else {
+            // return $sUrl
+            return $sUrl;
+        }
     }
 
     // --------------------------------------------------------------------------
@@ -327,7 +333,8 @@ class Local extends Base implements Driver
         $sUrl = str_replace('{{hash}}', $sHash, $sUrl);
         $sUrl = str_replace('{{filename}}', urlencode($sFilename), $sUrl);
 
-        return $sUrl;
+            return $sUrl;
+        }
     }
 
     // --------------------------------------------------------------------------
@@ -369,7 +376,13 @@ class Local extends Base implements Driver
         $sUrl = str_replace('{{filename}}', $sFilename, $sUrl);
         $sUrl = str_replace('{{extension}}', $sExtension, $sUrl);
 
-        return $sUrl;
+        //  Check for env for CDN_URL override env
+        if (!empty($_ENV['CDN_URL'])) {
+            return str_replace('localhost', $_ENV['CDN_URL'], $sUrl); // Local dev hack
+        } else {
+            // return $sUrl
+            return $sUrl;
+        }
     }
 
     // --------------------------------------------------------------------------
@@ -411,7 +424,13 @@ class Local extends Base implements Driver
         $sUrl = str_replace('{{filename}}', $sFilename, $sUrl);
         $sUrl = str_replace('{{extension}}', $sExtension, $sUrl);
 
-        return $sUrl;
+        //  Check for env for CDN_URL override env
+        if (!empty($_ENV['CDN_URL'])) {
+            return str_replace('localhost', $_ENV['CDN_URL'], $sUrl); // Local dev hack
+        } else {
+            // return $sUrl
+            return $sUrl;
+        }
     }
 
     // --------------------------------------------------------------------------


### PR DESCRIPTION
## The problem

Working with image heavy sites locally sucks, broken image urls are the main culprit

## The solution 

On EZ me and gary have been working with a hack that str_replaces `localhost` with www.egonzehnder.com in order that we're serving images from the live site

## What this PR does

 fformalises that a bit - allows you to turn this functionality on and off by way of the `CDN_URL` env var